### PR TITLE
.profile_program-specific/git - Minor enhancement for gg_replace (tested on linux only)

### DIFF
--- a/.profile_program-specific/git
+++ b/.profile_program-specific/git
@@ -50,7 +50,7 @@ gg_replace() {
     fi
 
     while [[ "$#" -gt "0" ]]; do
-      for file in `git grep -l $find -- $1`; do
+      for file in `git grep -l "$find" -- $1`; do
         if [[ $(uname) = 'Darwin' ]]; then
           #for BSD flavors of sed (sorry to not check for non-Mac systems :( )
           sed -e "s/$find/$replace/g" -i '' $file


### PR DESCRIPTION
Support find/replace for terms with spaces. For example, gg_replace "an cappuchino" "a cappuccino" *.html
